### PR TITLE
fix: corrigir URL do webhook para usar serviço principal em produção

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,8 @@ DB_PASSWORD=sua_senha_mysql
 DB_NAME=servico_vendas
 
 # URL do webhook externo para notificar vendas
-EXTERNAL_WEBHOOK_URL=http://localhost:3001/api/webhook/pagamento
+# Se não definida, será construída automaticamente baseada no SERVICO_PRINCIPAL_URL
+# EXTERNAL_WEBHOOK_URL=http://localhost:3000/api/webhook/pagamento
 
 # Configurações do servidor
 PORT=3000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,7 +63,7 @@ services:
       - RATE_LIMIT_WINDOW_MS=900000
       - RATE_LIMIT_MAX_REQUESTS=100
       - CRONJOB_INTERVAL_SECONDS=10
-      - EXTERNAL_WEBHOOK_URL=http://localhost:3000/api/webhook/pagamento
+      - EXTERNAL_WEBHOOK_URL=http://servico-principal:3000/api/webhook/pagamento
       - AWS_ACCESS_KEY_ID=test
       - AWS_SECRET_ACCESS_KEY=test
       - AWS_DEFAULT_REGION=us-east-1

--- a/src/domain/services/WebhookService.ts
+++ b/src/domain/services/WebhookService.ts
@@ -8,7 +8,9 @@ export class WebhookService {
   private readonly timeoutMs: number = 5000;
 
   constructor() {
-    this.webhookUrl = process.env.EXTERNAL_WEBHOOK_URL || 'http://localhost:3001/api/webhook/pagamento';
+    // Se EXTERNAL_WEBHOOK_URL não estiver definida, usa o SERVICO_PRINCIPAL_URL como base
+    const servicoPrincipalUrl = process.env.SERVICO_PRINCIPAL_URL || 'http://localhost:3000';
+    this.webhookUrl = process.env.EXTERNAL_WEBHOOK_URL || `${servicoPrincipalUrl}/api/webhook/pagamento`;
   }
 
   async notificarVendaAprovada(venda: Venda): Promise<boolean> {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -52,6 +52,12 @@ variable "servico_principal_url" {
   default     = "http://fiap-vehicle-management-alb-1408414491.us-east-1.elb.amazonaws.com"
 }
 
+variable "external_webhook_url" {
+  description = "URL do webhook externo para notificar vendas aprovadas"
+  type        = string
+  default     = ""  # Se vazio, será construído baseado no servico_principal_url
+}
+
 # Data sources
 data "aws_availability_zones" "available" {
   state = "available"
@@ -437,6 +443,10 @@ resource "aws_ecs_task_definition" "app" {
         {
           name  = "SERVICO_PRINCIPAL_URL"
           value = var.servico_principal_url
+        },
+        {
+          name  = "EXTERNAL_WEBHOOK_URL"
+          value = var.external_webhook_url != "" ? var.external_webhook_url : "${var.servico_principal_url}/api/webhook/pagamento"
         },
         {
           name  = "JWT_SECRET"


### PR DESCRIPTION
- WebhookService agora usa SERVICO_PRINCIPAL_URL como base quando EXTERNAL_WEBHOOK_URL não está definida
- Adicionar configuração EXTERNAL_WEBHOOK_URL no Terraform para produção AWS
- Atualizar docker-compose.yml para usar URL correta do serviço principal
- Adicionar testes para validar lógica de construção da URL do webhook
- Atualizar documentação para refletir nova configuração